### PR TITLE
Add function to kill useless alarms

### DIFF
--- a/Kill_Useless_Alarms/SETUP.md
+++ b/Kill_Useless_Alarms/SETUP.md
@@ -1,17 +1,16 @@
-Kill_Old_Dashboards is a lambda function that removes old CloudWatch Dashboards.
+Kill_Useless_Alarms is a lambda function that removes CloudWatch Alarms related to instances that no longer exist.
 
-Kill_Old_Dashboards checks for CloudWatch Dashboards every day.
-It removes any Dashboards that were created more than 3 days before (timing is configurable).
-It will not remove any Dashboards that have 'Keep' in their name.
+Kill_Useless_Alarms checks for defunct CloudWatch Alarms every day.
+Instances that were recently killed (such that they exist in state "Terminated" as opposed to don't exist at all) will be deleted the following day.
 
 # Setup Lambda Function
 
 *Create a new lambda functions.*
 
-## Function Kill_Old_Dashboards
+## Function Kill_Useless_Alarms
 
 ### Basic information
-**Function name**:`Kill_Old_Dashboards`  
+**Function name**:`Kill_Useless_Alarms`  
 **Runtime**: Python 3.8 or Python 3.9  
 **Permissions**: **Execution role**: Use an existing role:  `LambdaFullAccess`
 
@@ -30,8 +29,7 @@ If it does not:
 **Retry attempts**: 0
 
 ### Configure the lambda function code
-* Copy Kill_Old_Dashboards/`lambda_function.py` into the code area.
-* If you would like for the Dashboard removal age to be anything other than 3 days, edit the `timedelta`
+* Copy Kill_Useless_Alarms/`lambda_function.py` into the code area.
 * Deploy.
 
 # Setup EventBridge Rules
@@ -48,4 +46,4 @@ If it does not:
 ### Target 1:
 **Target type**: AWS service
 **Select a target**: Lambda function
-**Function**: Kill_Old_Dashboards
+**Function**: Kill_Useless_Alarms

--- a/Kill_Useless_Alarms/lambda_function.py
+++ b/Kill_Useless_Alarms/lambda_function.py
@@ -2,6 +2,8 @@ import boto3
 import time
 
 def lambda_handler(event, lambda_context):
+    
+    ## Part 1: let's document all the instances we know about, in any state
     instance_list = []
     alarm_count = 0
     deleted_alarm_count = 0
@@ -22,6 +24,9 @@ def lambda_handler(event, lambda_context):
         else:
             all_instances=True
     print(f"{len(instance_list)} instances found (in any state)")
+
+    ## Part 2: Let's look at all the MetricAlarms we have that are specifically monitoring an instance's functioning in some way
+    ## Any alarm that monitors an instances that EC2 doesn't have a record of anymore should be deleted
     alarms = cw.describe_alarms(AlarmTypes=['MetricAlarm'])
     all_alarms = False
     while all_alarms == False:
@@ -45,5 +50,3 @@ def lambda_handler(event, lambda_context):
         else:
             all_alarms=True
     print(f"{deleted_alarm_count} alarms deleted (of {alarm_count} total alarms)")
-
-alarm_killer()

--- a/Kill_Useless_Alarms/lambda_function.py
+++ b/Kill_Useless_Alarms/lambda_function.py
@@ -1,0 +1,47 @@
+import boto3
+
+def lambda_handler(event, lambda_context):
+    instance_list = []
+    alarm_count = 0
+    deleted_alarm_count = 0
+    ec2 = boto3.client('ec2')
+    cw = boto3.client('cloudwatch')
+    instances = ec2.describe_instances()
+    instances_reservations = instances['Reservations']
+    all_instances=False
+    while all_instances==False:
+        for eachres in instances_reservations:
+            for eachinst in eachres['Instances']:
+                instance_list.append(eachinst['InstanceId'])
+        if 'NextToken' in instances.keys():
+            token = instances['NextToken']
+            instances = ec2.describe_instances(NextToken=token)
+            instances_reservations = instances['Reservations']
+            all_instances=False
+        else:
+            all_instances=True
+    print(f"{len(instance_list)} instances found (in any state)")
+    alarms = cw.describe_alarms(AlarmTypes=['MetricAlarm'])
+    all_alarms = False
+    while all_alarms == False:
+        for eachalarm in alarms['MetricAlarms']:
+            alarm_count += 1
+            for eachdim in eachalarm['Dimensions']:
+                if eachdim['Name'] == 'InstanceId':
+                    if eachdim['Value'] not in instance_list:
+                        deleted_alarm_count += 1
+                        print(f"{eachalarm['AlarmName']} belongs to an instance that no longer exists. Deleting")
+                        cw.delete_alarms(AlarmNames = [eachalarm['AlarmName']])
+                    else:
+                        print(f"Not deleting {eachalarm['AlarmName']}, belongs to an instance that still exists")
+                else:
+                    print(f"Not deleting {eachalarm['AlarmName']}, not an instance alarm")
+        if 'NextToken' in alarms.keys():
+            token = alarms['NextToken']
+            alarms = cw.describe_alarms(AlarmTypes=['MetricAlarm'],NextToken=token)
+            all_alarms=False
+        else:
+            all_alarms=True
+    print(f"{deleted_alarm_count} alarms deleted (of {alarm_count} total alarms)")
+
+alarm_killer()

--- a/Kill_Useless_Alarms/lambda_function.py
+++ b/Kill_Useless_Alarms/lambda_function.py
@@ -1,4 +1,5 @@
 import boto3
+import time
 
 def lambda_handler(event, lambda_context):
     instance_list = []
@@ -32,6 +33,7 @@ def lambda_handler(event, lambda_context):
                         deleted_alarm_count += 1
                         print(f"{eachalarm['AlarmName']} belongs to an instance that no longer exists. Deleting")
                         cw.delete_alarms(AlarmNames = [eachalarm['AlarmName']])
+                        time.sleep(1) #avoid throttling
                     else:
                         print(f"Not deleting {eachalarm['AlarmName']}, belongs to an instance that still exists")
                 else:


### PR DESCRIPTION
Adds a function that runs daily and kills metric alarms created to alarm a particular instance that no longer exists. Distributed-things typically do their best to clean these up, but occasionally fail, leaving lots of alarms behind; at 0.10/alarm/month, this starts as not much money but can definitely add up if you let them accumulate. 

Sometimes the CloudWatch alarm deletion gets over-pinged in my experience, so I've added a one second throttle after an alarm gets deleted). In theory, this ends up meaning at most this function may top out at ~875 deleted alarms per day when run in an automated fashion (since Lambda functions have a 900 second maximum). That should be enough for all but the most extreme circumstances; if you truly have thousands of deleted alarms and want them all gone ASAP, nothing would stop you from repeatedly "testing" the Lambda function every 15 minutes until they were all gone. 